### PR TITLE
Preventing prompt while building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RE
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
  && apt-get update -qqy \
- && apt-get -qqy install google-chrome-stable \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qqy install google-chrome-stable \
  && rm /etc/apt/sources.list.d/google-chrome.list \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Currently there is a prompt while installing google-chrome-stable and configuring libssl1.1:amd64. I added an temporary environment variable which should prevent this prompt.

To test if this works, please run `docker build -t <some tag name> .`