### PR TITLE
Updated dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM heroku/heroku:18-build
 
 # Which versions?
-ENV RUBY_MAJOR_VERSION 2.6.0
-ENV RUBY_VERSION 2.6.4
+ENV RUBY_MAJOR_VERSION 2.7.0
+ENV RUBY_VERSION 2.7.0
+# https://devcenter.heroku.com/articles/ruby-support#libraries
 ENV BUNDLER_VERSION 2.0.2
-ENV NODE_VERSION 12.9.0
-ENV YARN_VERSION 1.17.3
+ENV NODE_VERSION 12.14.1
+ENV YARN_VERSION 1.21.1
 
 ENV LC_ALL en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Usage: `FROM nerdsandcompany/docker-heroku-rails`
 # Specifications
 
 * Heroku 18
-* Ruby 2.6.4
+* Ruby 2.7.0
 * Bundler 2.0.2
-* Node 12.9.0
+* Node 12.14.1
+* Yarn 1.21.1
 * Chrome
 * ChromeDriver


### PR DESCRIPTION
Ruby 2.6.4 -> 2.7.0
Node 12.9.0 -> 12.14.1
Yarn 1.17.3 -> 1.21.1